### PR TITLE
Return with an exit code if we miss translations

### DIFF
--- a/src/Commands/CheckCommand.php
+++ b/src/Commands/CheckCommand.php
@@ -84,6 +84,8 @@ class CheckCommand extends AbstractCommand
         $this->line('');
         $this->showMessage();
         $this->line('');
+
+		return $this->count;
     }
 
     /* ------------------------------------------------------------------------------------------------

--- a/src/Commands/CheckCommand.php
+++ b/src/Commands/CheckCommand.php
@@ -41,7 +41,7 @@ class CheckCommand extends AbstractCommand
      *
      * @var int
      */
-    private $count = 0;
+    private $missingTranslations = 0;
 
     /* -----------------------------------------------------------------
      |  Constructor
@@ -57,7 +57,7 @@ class CheckCommand extends AbstractCommand
     {
         $this->name    = $this->signature;
         $this->checker = $checker;
-        $this->count   = 0;
+        $this->missingTranslations   = 0;
 
         parent::__construct();
     }
@@ -85,13 +85,14 @@ class CheckCommand extends AbstractCommand
         $this->showMessage();
         $this->line('');
 
-		return $this->count;
+        return $this->getExitCode();
     }
 
-    /* ------------------------------------------------------------------------------------------------
-     |  Other Functions
-     | ------------------------------------------------------------------------------------------------
+    /* -----------------------------------------------------------------
+     |  Other Methods
+     | -----------------------------------------------------------------
      */
+
     /**
      * Prepare table rows.
      *
@@ -106,12 +107,12 @@ class CheckCommand extends AbstractCommand
         foreach ($missing as $locale => $translations) {
             foreach ($translations as $translation) {
                 $rows[] = [$locale, $translation];
-                $this->count++;
+                $this->missingTranslations++;
             }
             $rows[] = $this->tableSeparator();
         }
 
-        $rows[] = ['Total', "{$this->count} translations are missing."];
+        $rows[] = ['Total', "{$this->missingTranslations} translations are missing."];
 
         return $rows;
     }
@@ -123,9 +124,29 @@ class CheckCommand extends AbstractCommand
      */
     private function showMessage()
     {
-        if ($this->count > 0)
+        if ($this->hasMissingTranslations())
             $this->comment('Try to fix your translations and run again the `trans:check` command.');
         else
             $this->info('No missing translations, YOU ROCK !! (^_^)b');
+    }
+
+    /**
+     * Get the exit code.
+     *
+     * @return int
+     */
+    protected function getExitCode()
+    {
+        return $this->hasMissingTranslations() ? 1 : 0;
+    }
+
+    /**
+     * Check if has missing translations.
+     *
+     * @return bool
+     */
+    protected function hasMissingTranslations()
+    {
+        return $this->missingTranslations > 0;
     }
 }

--- a/tests/Commands/CheckCommandTest.php
+++ b/tests/Commands/CheckCommandTest.php
@@ -21,12 +21,29 @@ class CheckCommandTest extends TestCase
     {
         $this->mock(TransChecker::class, function ($mock) {
             $mock->shouldReceive('check')->andReturn([]);
+
             return $mock;
         });
+
         $this->artisan('trans:check')
              ->assertExitCode(0);
+    }
 
-        static::assertTrue(true);
+    /** @test */
+    public function it_has_an_exit_code_if_we_miss_something()
+    {
+        $this->mock(TransChecker::class, function ($mock) {
+            $mock->shouldReceive('check')->andReturn([
+                'en' => [
+                    'file.message',
+                ],
+            ]);
+
+            return $mock;
+        });
+
+        $this->artisan('trans:check')
+             ->assertExitCode(1);
     }
 
     /** @test */

--- a/tests/Commands/CheckCommandTest.php
+++ b/tests/Commands/CheckCommandTest.php
@@ -1,5 +1,6 @@
 <?php namespace Arcanedev\LaravelLang\Tests\Commands;
 
+use Arcanedev\LaravelLang\Contracts\TransChecker;
 use Arcanedev\LaravelLang\Tests\TestCase;
 
 /**
@@ -18,9 +19,29 @@ class CheckCommandTest extends TestCase
     /** @test */
     public function it_can_run_command()
     {
+        $this->mock(TransChecker::class, function ($mock) {
+            $mock->shouldReceive('check')->andReturn([]);
+            return $mock;
+        });
         $this->artisan('trans:check')
              ->assertExitCode(0);
 
         static::assertTrue(true);
+    }
+
+    /** @test */
+    public function it_has_an_exit_code_if_we_miss_something()
+    {
+        $this->doesNotPerformAssertions();
+        $this->mock(TransChecker::class, function ($mock) {
+            $mock->shouldReceive('check')->andReturn([
+                'en' => [
+                    'file.message',
+                ],
+            ]);
+            return $mock;
+        });
+        $this->artisan('trans:check')
+            ->assertExitCode(1);
     }
 }

--- a/tests/Commands/CheckCommandTest.php
+++ b/tests/Commands/CheckCommandTest.php
@@ -45,20 +45,4 @@ class CheckCommandTest extends TestCase
         $this->artisan('trans:check')
              ->assertExitCode(1);
     }
-
-    /** @test */
-    public function it_has_an_exit_code_if_we_miss_something()
-    {
-        $this->doesNotPerformAssertions();
-        $this->mock(TransChecker::class, function ($mock) {
-            $mock->shouldReceive('check')->andReturn([
-                'en' => [
-                    'file.message',
-                ],
-            ]);
-            return $mock;
-        });
-        $this->artisan('trans:check')
-            ->assertExitCode(1);
-    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -90,7 +90,7 @@ abstract class TestCase extends BaseTestCase
 
         $filesystem->copyDirectory(
             realpath(__DIR__.DS.'fixtures'.DS.'lang'),
-            realpath(base_path('resources'.DS.'lang'))
+            realpath(resource_path('lang'))
         );
     }
 


### PR DESCRIPTION
If anything is on the way we want we get an exit code 0, anything else means there is a problem.

With returning an exit code if we miss something we can use it in automated testing. (Like Gitlab CI or Travis) to directly warn that something is missing.